### PR TITLE
Fix hard-coded username; add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This will create, update and delete resources in the repository. So you may **no
 
 Also, this is doing a cursory test. It relies on the response from Fedora and does not verify changes to the RDF.
 
+Note: in order to test authorization, please first verify that your Fedora repository in configured to use authorization.
+Check the `repository.json` in use, and verify that the `security` block contains a `providers` list such as:
+
+    "providers" : [
+        { "classname" : "org.fcrepo.auth.common.ServletContainerAuthenticationProvider" }
+    ]
+
 ## Usage
 
 Edit the `config` file and review the default variables to ensure the tests are pointing at your repository. 

--- a/authz_tests.sh
+++ b/authz_tests.sh
@@ -10,6 +10,12 @@ PARENT="/test_authz"
 checkForReTest $PARENT
 
 # Tests
+echo "Checking that authZ is enabled"
+RANDOM=$(openssl rand -hex 16)
+
+HTTP_RES=$(curl $CURL_OPTS -XGET -u${RANDOM}:${RANDOM} ${FEDORA_URL})
+resultCheck 401 $HTTP_RES
+
 echo "Create \"cover\" container"
 HTTP_RES=$(curl $CURL_OPTS -XPUT -u${AUTH_USER}:${AUTH_PASS} ${FEDORA_URL}${PARENT}/cover)
 resultCheck 201 $HTTP_RES
@@ -50,7 +56,7 @@ HTTP_RES=$(curl $CURL_OPTS -XPUT -u${AUTH_USER}:${AUTH_PASS} ${FEDORA_URL}${PARE
 resultCheck 201 $HTTP_RES
 
 echo "Define \"authorization\""
-HTTP_RES=$(curl $CURL_OPTS -XPATCH -u${AUTH_USER}:${AUTH_PASS} -H"Content-type: application/sparql-update" --data-binary "@${RSCDIR}/authorization.sparql" ${FEDORA_URL}${PARENT}/my-acls/acl/authorization)
+HTTP_RES=$(sed "s/acl:agent \"adminuser\"/acl:agent \"${AUTH2_USER}\"/g" ${RSCDIR}/authorization.sparql | curl $CURL_OPTS -XPATCH -u${AUTH_USER}:${AUTH_PASS} -H"Content-type: application/sparql-update" --data-binary "@-" ${FEDORA_URL}${PARENT}/my-acls/acl/authorization)
 resultCheck 204 $HTTP_RES
 
 echo "Link \"acl\" to \"cover\""


### PR DESCRIPTION
This change allows the tests to work with RC3 on my machine with a postgres-based backend (I had to modify the `repository.json` file as described in the `README`).
