### PR TITLE
Fix WebAC for different FEDORA_PASS and tomcat vs jetty usernames

### DIFF
--- a/authz_tests.sh
+++ b/authz_tests.sh
@@ -53,8 +53,9 @@ echo "Define \"authorization\""
 HTTP_RES=$(curl $CURL_OPTS -XPATCH -u${AUTH_USER}:${AUTH_PASS} -H"Content-type: application/sparql-update" --data-binary "@${RSCDIR}/authorization.sparql" ${FEDORA_URL}${PARENT}/my-acls/acl/authorization)
 resultCheck 204 $HTTP_RES
 
+PATCH=$(tr "\r\n" " " < ${RSCDIR}/link_acl_patch.sparql | sed -e "s|{FEDORA_PATH}|${FEDORA_PATH}|")
 echo "Link \"acl\" to \"cover\""
-HTTP_RES=$(curl $CURL_OPTS -XPATCH -u${AUTH_USER}:${AUTH_PASS} -H"Content-type: application/sparql-update" --data-binary "@${RSCDIR}/link_acl_patch.sparql" ${FEDORA_URL}${PARENT}/cover)
+HTTP_RES=$(echo ${PATCH} | curl $CURL_OPTS -XPATCH -u${AUTH_USER}:${AUTH_PASS} -H"Content-type: application/sparql-update" --upload-file - ${FEDORA_URL}${PARENT}/cover)
 resultCheck 204 $HTTP_RES
 
 echo "verifyAuthZ"

--- a/resources/authorization.sparql
+++ b/resources/authorization.sparql
@@ -5,6 +5,6 @@ INSERT {
 <> a acl:Authorization ;
 acl:accessToClass pcdm:Object ;
 acl:mode acl:Read, acl:Write;
-acl:agent "adminuser" .
+acl:agent "adminuser", "user2" .
 } WHERE { }
 

--- a/resources/link_acl_patch.sparql
+++ b/resources/link_acl_patch.sparql
@@ -1,6 +1,6 @@
 PREFIX acl: <http://www.w3.org/ns/auth/acl#>
 
 INSERT {
-<> acl:accessControl </fcrepo/rest/test_authz/my-acls/acl>
+<> acl:accessControl <{FEDORA_PATH}/test_authz/my-acls/acl>
 
 } WHERE { }


### PR DESCRIPTION
Testing some fcrepo-webapp-plus builds using `mvn jetty:run` I discovered that the authz tests failed because they were hardcoded to assume the `/fcrepo/rest` path and did not include the `user2` user in authorizations.
